### PR TITLE
Integrate EGSDE-diffusers as a community DiffusionPipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **EGSDE community pipeline** (`examples/community/egsde/`): `load_egsde_community_pipeline` and `EGSDEPipeline` wrap a local checkout of [Bili-Sakura/EGSDE-diffusers](https://github.com/Bili-Sakura/EGSDE-diffusers) for NeurIPS 2022 energy-guided unpaired translation (cat2dog / wild2dog / male2female profiles or custom checkpoints).
 - **JiT backbone** (`src/models/dit/jit.py`): `JiTBackbone` and `JIT_CONFIGS` — Just image Transformer adapted for the same DDBM/bridge calling convention as `SiTBackbone` (timestep + optional `xT` concat). Based on [LTH14/JiT](https://github.com/LTH14/JiT).
 
 ## [0.5.1] - 2026-03-15

--- a/examples/community/README.md
+++ b/examples/community/README.md
@@ -34,6 +34,7 @@ from examples.community.parallel_gan import ParaGAN, Resrecon, ParallelGANTraine
 | [`bbdm/`](bbdm/) | [Li et al., CVPR 2023](https://arxiv.org/abs/2205.07680) | BBDM for original xuekt98/BBDM-style checkpoints with OpenAI UNet key layout |
 | [`parallel_gan/`](parallel_gan/) | [Wang et al., TGRS 2022](https://ieeexplore.ieee.org/document/9864654) | SAR-to-Optical translation with hierarchical latent features via a two-stage approach (reconstruction + translation) |
 | [`e3diff/`](e3diff/) | [Qin et al., IEEE GRSL 2024](https://ieeexplore.ieee.org/document/10767752) | Efficient End-to-End Diffusion Model for one-step SAR-to-Optical translation using a conditional U-Net (CPEN) and two-stage diffusion + GAN training |
+| [`egsde/`](egsde/) | [Zhao et al., NeurIPS 2022](https://arxiv.org/abs/2207.06635) | EGSDE unpaired image-to-image translation with energy-guided VP-SDEs; requires local [EGSDE-diffusers](https://github.com/Bili-Sakura/EGSDE-diffusers) checkout and pretrained weights |
 | [`openearthmap_sar/`](openearthmap_sar/) | [Park et al., ECCV 2020](https://arxiv.org/abs/2007.15651) | CUT models for SAR ↔ optical image translation with anti-aliased ResNet generator (opt2sar, sar2opt, seman2opt, seman2sar, etc.) |
 | [`sar2optical/`](sar2optical/) | [Isola et al., CVPR 2017](https://arxiv.org/abs/1611.07004) | Pix2Pix cGAN SAR-to-Optical translation, adapted from yuuIind/SAR2Optical |
 | [`lddbm/`](../lddbm/) | [Bosch Research, NeurIPS 2025](https://github.com/boschresearch/Multimodal-Distribution-Translation-MDT) | LDDBM: Latent diffusion bridge for super-resolution (16→128); training in `examples/lddbm/` |
@@ -375,6 +376,31 @@ losses = trainer.train_step(sar_batch, optical_batch)
   pages={1-1},
   doi={10.1109/LGRS.2024.3506566}}
 ```
+
+---
+
+### EGSDE (Community)
+
+**Paper:** *EGSDE: Unpaired Image-to-Image Translation via Energy-Guided Stochastic Differential Equations* (Zhao et al., NeurIPS 2022)
+
+**Source:** [Bili-Sakura/EGSDE-diffusers](https://github.com/Bili-Sakura/EGSDE-diffusers) (clone locally; ships `guided_diffusion`, `profiles/`, and VP-EGSDE sampling).
+
+**Architecture:** Pretrained score model (ADM or DDPM) plus a domain-specific energy extractor (DSE) and a domain-independent pathway via learnable resizers. Inference follows the VP-EGSDE loop in the upstream `runners/egsde.py`.
+
+**Quick start:**
+
+```python
+from examples.community.egsde import load_egsde_community_pipeline
+
+pipe = load_egsde_community_pipeline(
+    "/path/to/EGSDE-diffusers",
+    task="cat2dog",
+    device="cuda",
+)
+out = pipe(source_image=image, output_type="pil")
+```
+
+See [egsde/README.md](egsde/README.md) for setup, custom checkpoint loading, and citation.
 
 ---
 

--- a/examples/community/egsde/README.md
+++ b/examples/community/egsde/README.md
@@ -1,0 +1,60 @@
+# EGSDE (community)
+
+**Paper:** [EGSDE: Unpaired Image-to-Image Translation via Energy-Guided Stochastic Differential Equations](https://arxiv.org/abs/2207.06635) (Zhao et al., NeurIPS 2022)
+
+**Upstream:** [Bili-Sakura/EGSDE-diffusers](https://github.com/Bili-Sakura/EGSDE-diffusers) (diffusers-oriented fork of [ML-GSAI/EGSDE](https://github.com/ML-GSAI/EGSDE))
+
+This folder wraps the upstream VP-EGSDE implementation so you can run inference from **pytorch-image-translation-models** with the same `DiffusionPipeline`-style API used elsewhere in the repo.
+
+## Setup
+
+1. Clone the upstream repository next to this project (or anywhere on disk):
+
+   ```bash
+   git clone https://github.com/Bili-Sakura/EGSDE-diffusers.git
+   ```
+
+2. Download pretrained diffusion checkpoints and domain-specific extractors (DSE) as described in the [upstream README](https://github.com/Bili-Sakura/EGSDE-diffusers/blob/master/README.md) into `EGSDE-diffusers/pretrained_model/`.
+
+## Inference
+
+```python
+from examples.community.egsde import load_egsde_community_pipeline
+from PIL import Image
+
+pipe = load_egsde_community_pipeline(
+    "/path/to/EGSDE-diffusers",
+    task="cat2dog",
+    device="cuda",
+)
+pipe.to("cuda")
+
+src = Image.open("cat.png").convert("RGB")
+out = pipe(source_image=src, output_type="pil")
+out.images[0].save("dog_like.png")
+```
+
+### Custom checkpoints (no profile)
+
+```python
+pipe = load_egsde_community_pipeline(
+    "/path/to/EGSDE-diffusers",
+    task=None,
+    ckpt="/path/to/score_model.pt",
+    dsepath="/path/to/dse.pt",
+    config_path="/path/to/config.yml",
+    diffusionmodel="ADM",  # or "DDPM"
+    device="cuda",
+)
+```
+
+## Citation
+
+```bibtex
+@article{zhao2022egsde,
+  title={Egsde: Unpaired image-to-image translation via energy-guided stochastic differential equations},
+  author={Zhao, Min and Bao, Fan and Li, Chongxuan and Zhu, Jun},
+  journal={arXiv preprint arXiv:2207.06635},
+  year={2022}
+}
+```

--- a/examples/community/egsde/__init__.py
+++ b/examples/community/egsde/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: EGSDE (Zhao et al., NeurIPS 2022) — https://github.com/Bili-Sakura/EGSDE-diffusers
+
+"""EGSDE community pipeline (Energy-Guided Stochastic Differential Equations)."""
+
+from .model import EGSDE_TASKS, EGSDETask
+from .pipeline import (
+    EGSDEPipeline,
+    EGSDEPipelineOutput,
+    load_egsde_community_pipeline,
+)
+
+__all__ = [
+    "EGSDE_TASKS",
+    "EGSDETask",
+    "EGSDEPipeline",
+    "EGSDEPipelineOutput",
+    "load_egsde_community_pipeline",
+]

--- a/examples/community/egsde/model.py
+++ b/examples/community/egsde/model.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: EGSDE (Zhao et al., NeurIPS 2022) — https://github.com/Bili-Sakura/EGSDE-diffusers
+
+"""Constants for the EGSDE community pipeline."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+# Two-domain translation presets shipped with the upstream repo (profiles/*/args.py).
+EGSDE_TASKS: tuple[str, ...] = ("cat2dog", "wild2dog", "male2female")
+
+EGSDETask = Literal["cat2dog", "wild2dog", "male2female"]

--- a/examples/community/egsde/pipeline.py
+++ b/examples/community/egsde/pipeline.py
@@ -1,0 +1,420 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: EGSDE (Zhao et al., NeurIPS 2022) — https://github.com/Bili-Sakura/EGSDE-diffusers
+
+"""Diffusers-style wrapper for EGSDE (Energy-Guided Stochastic Differential Equations)."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import yaml
+from PIL import Image
+
+from diffusers import DiffusionPipeline
+from diffusers.utils import BaseOutput, numpy_to_pil
+
+from .model import EGSDE_TASKS
+
+
+def _ensure_egsde_path(egsde_src_path: Optional[str | Path]) -> Path:
+    """Resolve EGSDE-diffusers checkout root."""
+    if egsde_src_path is not None:
+        p = Path(egsde_src_path)
+        if p.is_dir() and (p / "runners" / "egsde.py").is_file() and (p / "guided_diffusion" / "script_util.py").is_file():
+            return p.resolve()
+        raise FileNotFoundError(
+            f"EGSDE-diffusers source not found at {p}. Expected runners/egsde.py and guided_diffusion/script_util.py."
+        )
+
+    root = Path(__file__).resolve().parents[4]
+    candidates = [
+        root / "EGSDE-diffusers",
+        root / "projects" / "EGSDE-diffusers",
+        Path.cwd() / "EGSDE-diffusers",
+        Path.cwd() / "projects" / "EGSDE-diffusers",
+    ]
+    for p in candidates:
+        if p.is_dir() and (p / "runners" / "egsde.py").is_file():
+            return p.resolve()
+
+    raise FileNotFoundError(
+        "EGSDE-diffusers source not found. Clone https://github.com/Bili-Sakura/EGSDE-diffusers.git and pass "
+        "egsde_src_path, or place it at ./EGSDE-diffusers or ./projects/EGSDE-diffusers."
+    )
+
+
+def _inject_egsde_path(egsde_root: Path) -> None:
+    s = str(egsde_root.resolve())
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+
+def _load_profile_args(egsde_root: Path, task: str) -> Namespace:
+    if task not in EGSDE_TASKS:
+        raise ValueError(f"Unknown EGSDE task {task!r}. Choose one of {EGSDE_TASKS}.")
+    args_path = egsde_root / "profiles" / task / "args.py"
+    if not args_path.is_file():
+        raise FileNotFoundError(f"Missing profile args: {args_path}")
+    spec = importlib.util.spec_from_file_location(f"egsde_profile_{task}", args_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load profile module from {args_path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    args = copy.copy(mod.argsall)
+    root = egsde_root.resolve()
+
+    def _abs(p: str) -> str:
+        pp = Path(p)
+        return str(pp.resolve()) if pp.is_absolute() else str((root / pp).resolve())
+
+    args.ckpt = _abs(args.ckpt)
+    args.dsepath = _abs(args.dsepath)
+    args.config_path = _abs(args.config_path)
+    if hasattr(args, "testdata_path"):
+        args.testdata_path = _abs(args.testdata_path)
+    return args
+
+
+def _load_config_namespace(config_path: str | Path) -> Namespace:
+    from tool.utils import dict2namespace
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    return dict2namespace(raw)
+
+
+def _normalize_state_dict(states: object) -> object:
+    if not isinstance(states, dict):
+        return states
+    keys = list(states.keys())
+    if not keys:
+        return states
+    if all(isinstance(k, str) and k.startswith("module.") for k in keys):
+        return {k[7:]: v for k, v in states.items()}
+    return states
+
+
+def _prepare_source_batch(
+    source_image: Union[torch.Tensor, Image.Image, List[Image.Image], np.ndarray],
+    *,
+    image_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if isinstance(source_image, Image.Image):
+        source_image = [source_image]
+
+    if isinstance(source_image, list) and source_image and isinstance(source_image[0], Image.Image):
+        source_image = torch.stack(
+            [torch.from_numpy(np.array(img.convert("RGB"), dtype=np.float32)).permute(2, 0, 1) for img in source_image]
+        )
+
+    if isinstance(source_image, np.ndarray):
+        source_image = torch.from_numpy(source_image)
+
+    if source_image.ndim == 3:
+        source_image = source_image.unsqueeze(0)
+    if source_image.shape[1] not in (1, 3, 4) and source_image.shape[-1] in (1, 3, 4):
+        source_image = source_image.permute(0, 3, 1, 2)
+    if source_image.shape[1] == 1:
+        source_image = source_image.repeat(1, 3, 1, 1)
+    if source_image.shape[1] > 3:
+        source_image = source_image[:, :3]
+
+    if source_image.dtype != torch.float32:
+        source_image = source_image.float()
+
+    if source_image.max() > 1.0:
+        source_image = source_image / 255.0
+    source_image = source_image.clamp(0, 1).mul(2).sub(1)
+
+    if source_image.shape[-1] != image_size or source_image.shape[-2] != image_size:
+        source_image = F.interpolate(
+            source_image, size=(image_size, image_size), mode="bicubic", align_corners=False
+        ).clamp(-1.0, 1.0)
+
+    return source_image.to(device=device, dtype=dtype)
+
+
+class EGSDEPipelineOutput(BaseOutput):
+    """Output of :class:`EGSDEPipeline`."""
+
+    images: Union[List[Image.Image], np.ndarray, torch.Tensor]
+
+
+class EGSDEPipeline(DiffusionPipeline):
+    """Unpaired image-to-image translation with EGSDE energy guidance."""
+
+    model_cpu_offload_seq = "score_model"
+
+    def __init__(self, args: Namespace, config: Namespace, egsde_root: Path, device: str | torch.device) -> None:
+        self.args = args
+        self.config = config
+        self._egsde_root = Path(egsde_root)
+        self._device = torch.device(device)
+        self._die_batch = -1
+        self._down: Optional[torch.nn.Module] = None
+        self._up: Optional[torch.nn.Module] = None
+
+        from runners.egsde import EGSDE
+
+        schedule = EGSDE(args, config, device=self._device)
+        self.betas = schedule.betas
+        self.logvar = schedule.logvar
+
+        score_model, dse = self._build_score_and_dse(args, config, self._device)
+        super().__init__()
+        self.register_modules(score_model=score_model, dse=dse)
+
+    @staticmethod
+    def _build_score_and_dse(args: Namespace, config: Namespace, device: torch.device) -> tuple[torch.nn.Module, torch.nn.Module]:
+        from guided_diffusion.script_util import create_dse, create_model
+
+        if args.diffusionmodel == "ADM":
+            score_model = create_model(
+                image_size=config.data.image_size,
+                num_class=config.model.num_class,
+                num_channels=config.model.num_channels,
+                num_res_blocks=config.model.num_res_blocks,
+                learn_sigma=config.model.learn_sigma,
+                class_cond=config.model.class_cond,
+                attention_resolutions=config.model.attention_resolutions,
+                num_heads=config.model.num_heads,
+                num_head_channels=config.model.num_head_channels,
+                num_heads_upsample=config.model.num_heads_upsample,
+                use_scale_shift_norm=config.model.use_scale_shift_norm,
+                dropout=config.model.dropout,
+                resblock_updown=config.model.resblock_updown,
+                use_fp16=config.model.use_fp16,
+                use_new_attention_order=config.model.use_new_attention_order,
+            )
+        elif args.diffusionmodel == "DDPM":
+            from models.ddpm import Model
+
+            score_model = Model(config)
+        else:
+            raise ValueError(f"Unsupported diffusionmodel {args.diffusionmodel!r}; expected ADM or DDPM.")
+
+        states = torch.load(args.ckpt, map_location="cpu", weights_only=False)
+        states = _normalize_state_dict(states)
+        score_model.load_state_dict(states, strict=True)
+        score_model.to(device).eval()
+
+        dse = create_dse(
+            image_size=config.data.image_size,
+            num_class=config.dse.num_class,
+            classifier_use_fp16=config.dse.classifier_use_fp16,
+            classifier_width=config.dse.classifier_width,
+            classifier_depth=config.dse.classifier_depth,
+            classifier_attention_resolutions=config.dse.classifier_attention_resolutions,
+            classifier_use_scale_shift_norm=config.dse.classifier_use_scale_shift_norm,
+            classifier_resblock_updown=config.dse.classifier_resblock_updown,
+            classifier_pool=config.dse.classifier_pool,
+            phase=args.phase,
+        )
+        dse_states = torch.load(args.dsepath, map_location="cpu", weights_only=False)
+        dse_states = _normalize_state_dict(dse_states)
+        dse.load_state_dict(dse_states, strict=True)
+        dse.to(device).eval()
+
+        return score_model, dse
+
+    def _ensure_die(self, batch_size: int) -> tuple[torch.nn.Module, torch.nn.Module]:
+        from functions.resizer import Resizer
+
+        if batch_size == self._die_batch and self._down is not None and self._up is not None:
+            return self._down, self._up
+
+        h = int(self.config.data.image_size)
+        shape = (batch_size, 3, h, h)
+        shape_d = (batch_size, 3, int(h / self.args.down_N), int(h / self.args.down_N))
+        dev = self.device
+        self._down = Resizer(shape, 1 / self.args.down_N).to(dev)
+        self._up = Resizer(shape_d, self.args.down_N).to(dev)
+        self._die_batch = batch_size
+        return self._down, self._up
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.score_model.parameters()).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.score_model.parameters()).dtype
+
+    def to(self, *args, **kwargs):  # noqa: ANN002
+        out = super().to(*args, **kwargs)
+        self.betas = self.betas.to(self.device)
+        self.logvar = self.logvar.to(self.device)
+        self._die_batch = -1
+        self._down = None
+        self._up = None
+        return out
+
+    def _tensor_to_output(self, y: torch.Tensor, output_type: str) -> Union[List[Image.Image], np.ndarray, torch.Tensor]:
+        y = y.clamp(0.0, 1.0)
+        if output_type == "pil":
+            return numpy_to_pil(y.cpu().permute(0, 2, 3, 1).numpy())
+        if output_type == "np":
+            return y.cpu().permute(0, 2, 3, 1).numpy()
+        if output_type in ("pt", "latent"):
+            return y
+        raise ValueError(f"Unsupported output_type {output_type!r}; expected pil, np, or pt.")
+
+    def __call__(
+        self,
+        source_image: Union[torch.Tensor, Image.Image, List[Image.Image], np.ndarray],
+        *,
+        output_type: str = "pil",
+        return_dict: bool = True,
+    ) -> Union[EGSDEPipelineOutput, tuple]:
+        """Run VP-EGSDE sampling (source domain → target domain).
+
+        Autograd stays enabled because energy guidance computes gradients in ``egsde_sample``.
+        """
+        from datasets import inverse_rescale
+        from functions.denoising import egsde_sample
+
+        dev = self.device
+        dt = self.dtype
+        x0 = _prepare_source_batch(
+            source_image, image_size=int(self.config.data.image_size), device=dev, dtype=dt
+        )
+        n = x0.shape[0]
+        down, up = self._ensure_die(n)
+        die = (down, up)
+
+        y0 = x0
+        model = self.score_model
+        dse = self.dse
+        args = self.args
+        total_noise_levels = int(args.t)
+
+        for _it in range(int(args.sample_step)):
+            e = torch.randn_like(y0)
+            a = (1 - self.betas).cumprod(dim=0)
+            y = y0 * a[total_noise_levels - 1].sqrt() + e * (1.0 - a[total_noise_levels - 1]).sqrt()
+            for i in reversed(range(total_noise_levels)):
+                t = (torch.ones(n, device=dev, dtype=torch.long) * i).long()
+                xt = x0 * a[i].sqrt() + e * (1.0 - a[i]).sqrt()
+                y = egsde_sample(
+                    y=y,
+                    dse=dse,
+                    ls=args.ls,
+                    die=die,
+                    li=args.li,
+                    t=t,
+                    model=model,
+                    logvar=self.logvar,
+                    betas=self.betas,
+                    xt=xt,
+                    s1=args.s1,
+                    s2=args.s2,
+                    model_name=args.diffusionmodel,
+                )
+            y0 = y
+
+        y_out = inverse_rescale(y0)
+        images = self._tensor_to_output(y_out, output_type)
+        if not return_dict:
+            return (images,)
+        return EGSDEPipelineOutput(images=images)
+
+
+def load_egsde_community_pipeline(
+    egsde_src_path: Optional[str | Path] = None,
+    *,
+    task: Optional[str] = None,
+    device: str | torch.device = "cuda",
+    ckpt: Optional[str] = None,
+    dsepath: Optional[str] = None,
+    config_path: Optional[str | Path] = None,
+    diffusionmodel: Optional[str] = None,
+    t: Optional[int] = None,
+    ls: Optional[float] = None,
+    li: Optional[float] = None,
+    s1: Optional[str] = None,
+    s2: Optional[str] = None,
+    down_N: Optional[int] = None,
+    sample_step: Optional[int] = None,
+    phase: Optional[str] = None,
+    batch_size: Optional[int] = None,
+) -> EGSDEPipeline:
+    """Load EGSDE inference weights from a local EGSDE-diffusers checkout.
+
+    Either pass ``task`` (loads ``profiles/<task>/args.py``) or supply full checkpoint paths
+    and ``config_path`` plus ``diffusionmodel``.
+    """
+    root = _ensure_egsde_path(egsde_src_path)
+    _inject_egsde_path(root)
+
+    if task is not None:
+        args = _load_profile_args(root, task)
+    else:
+        missing = []
+        for name, val in (
+            ("ckpt", ckpt),
+            ("dsepath", dsepath),
+            ("config_path", config_path),
+            ("diffusionmodel", diffusionmodel),
+        ):
+            if val is None:
+                missing.append(name)
+        if missing:
+            raise ValueError(
+                "When task is None, the following arguments are required: " + ", ".join(missing) + ". "
+                "Alternatively pass task='cat2dog', 'wild2dog', or 'male2female'."
+            )
+        args = Namespace(
+            ckpt=str(Path(ckpt).resolve()),
+            dsepath=str(Path(dsepath).resolve()),
+            config_path=str(Path(config_path).resolve()),
+            diffusionmodel=diffusionmodel,
+            t=int(t) if t is not None else 500,
+            ls=float(ls) if ls is not None else 500.0,
+            li=float(li) if li is not None else 2.0,
+            s1=s1 or "cosine",
+            s2=s2 or "neg_l2",
+            phase=phase or "test",
+            sample_step=int(sample_step) if sample_step is not None else 1,
+            batch_size=int(batch_size) if batch_size is not None else 4,
+            down_N=int(down_N) if down_N is not None else 32,
+        )
+
+    if ckpt is not None:
+        args.ckpt = str(Path(ckpt).resolve())
+    if dsepath is not None:
+        args.dsepath = str(Path(dsepath).resolve())
+    if config_path is not None:
+        args.config_path = str(Path(config_path).resolve())
+    if diffusionmodel is not None:
+        args.diffusionmodel = diffusionmodel
+    if t is not None:
+        args.t = int(t)
+    if ls is not None:
+        args.ls = float(ls)
+    if li is not None:
+        args.li = float(li)
+    if s1 is not None:
+        args.s1 = s1
+    if s2 is not None:
+        args.s2 = s2
+    if down_N is not None:
+        args.down_N = int(down_N)
+    if sample_step is not None:
+        args.sample_step = int(sample_step)
+    if phase is not None:
+        args.phase = phase
+    if batch_size is not None:
+        args.batch_size = int(batch_size)
+
+    config = _load_config_namespace(args.config_path)
+    return EGSDEPipeline(args, config, root, device)

--- a/examples/community/egsde/train.py
+++ b/examples/community/egsde/train.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: EGSDE (Zhao et al., NeurIPS 2022) — https://github.com/Bili-Sakura/EGSDE-diffusers
+
+"""Training entrypoints for EGSDE live in the upstream repository.
+
+Train domain-specific energy extractors with:
+
+* ``python run_train_dse.py`` (see upstream ``README.md``).
+
+Score-model training uses `guided-diffusion <https://github.com/openai/guided-diffusion>`_
+or `DDIM <https://github.com/ermongroup/ddim>`_ as in the original paper.
+"""

--- a/tests/test_community_pipelines.py
+++ b/tests/test_community_pipelines.py
@@ -871,3 +871,71 @@ class TestDiffusionRouterPipeline:
                 "/tmp/nonexistent-diffusionrouter.pt",
                 device="cpu",
             )
+
+
+# ---------------------------------------------------------------------------
+# EGSDE (Bili-Sakura/EGSDE-diffusers)
+# ---------------------------------------------------------------------------
+
+
+class TestEGSDEPipeline:
+    """Tests for the EGSDE community pipeline wrapper."""
+
+    def test_egsde_imports(self):
+        from examples.community.egsde import (
+            EGSDE_TASKS,
+            EGSDEPipeline,
+            EGSDEPipelineOutput,
+            load_egsde_community_pipeline,
+        )
+
+        assert "cat2dog" in EGSDE_TASKS
+        assert EGSDEPipeline is not None
+        assert EGSDEPipelineOutput is not None
+        assert callable(load_egsde_community_pipeline)
+
+    def test_prepare_source_batch_resize(self):
+        from examples.community.egsde.pipeline import _prepare_source_batch
+
+        x = torch.rand(1, 3, 64, 64)
+        y = _prepare_source_batch(x, image_size=128, device=torch.device("cpu"), dtype=torch.float32)
+        assert y.shape == (1, 3, 128, 128)
+        assert y.min() >= -1.0
+        assert y.max() <= 1.0
+
+    def test_normalize_state_dict_strips_module_prefix(self):
+        from examples.community.egsde.pipeline import _normalize_state_dict
+
+        d = {"module.w": torch.zeros(1)}
+        out = _normalize_state_dict(d)
+        assert list(out.keys()) == ["w"]
+
+    def test_ensure_egsde_path_invalid_raises(self, tmp_path):
+        from examples.community.egsde.pipeline import _ensure_egsde_path
+
+        with pytest.raises(FileNotFoundError):
+            _ensure_egsde_path(tmp_path / "not-egsde")
+
+    def test_load_egsde_without_task_requires_fields(self, tmp_path):
+        from examples.community.egsde import load_egsde_community_pipeline
+
+        fake = tmp_path / "EGSDE-diffusers"
+        (fake / "runners").mkdir(parents=True)
+        (fake / "guided_diffusion").mkdir(parents=True)
+        (fake / "runners" / "egsde.py").write_text("# stub\n")
+        (fake / "guided_diffusion" / "script_util.py").write_text("# stub\n")
+
+        with pytest.raises(ValueError, match="task"):
+            load_egsde_community_pipeline(fake, task=None, device="cpu")
+
+    def test_load_egsde_bad_task_raises(self, tmp_path):
+        from examples.community.egsde import load_egsde_community_pipeline
+
+        fake = tmp_path / "EGSDE-diffusers"
+        (fake / "runners").mkdir(parents=True)
+        (fake / "guided_diffusion").mkdir(parents=True)
+        (fake / "runners" / "egsde.py").write_text("# stub\n")
+        (fake / "guided_diffusion" / "script_util.py").write_text("# stub\n")
+
+        with pytest.raises(ValueError, match="Unknown EGSDE task"):
+            load_egsde_community_pipeline(fake, task="unknown_task", device="cpu")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds a **community pipeline** under `examples/community/egsde/` that wraps a local checkout of [Bili-Sakura/EGSDE-diffusers](https://github.com/Bili-Sakura/EGSDE-diffusers) (NeurIPS 2022 EGSDE). It follows the same pattern as other external-method integrations (for example DiffusionRouter): resolve the repo root, prepend it to `sys.path`, load YAML config and checkpoints, and expose `load_egsde_community_pipeline` returning a `diffusers.DiffusionPipeline` subclass.

## What is included

- `EGSDEPipeline` with `__call__(source_image=..., output_type="pil"|"np"|"pt")` running the VP-EGSDE loop (energy terms require autograd; `__call__` is not wrapped in `torch.no_grad()`).
- Preset tasks `cat2dog`, `wild2dog`, `male2female` via upstream `profiles/*/args.py`, with optional per-field overrides.
- Custom loading when `task=None` by passing `ckpt`, `dsepath`, `config_path`, and `diffusionmodel` (`ADM` or `DDPM`).
- Domain-independent resizers (`Resizer`) are rebuilt when batch size or device changes after `to()`.
- State dict keys prefixed with `module.` are normalized for checkpoints saved under `DataParallel`.
- Documentation in `examples/community/egsde/README.md`, index row and quick start in `examples/community/README.md`, and a changelog entry under **Unreleased**.
- Tests for imports, `_prepare_source_batch`, state-dict normalization, path resolution, and loader validation.

## Notes

- Users must clone EGSDE-diffusers and download upstream pretrained weights (see upstream README); nothing is vendored into this repository.
- Full-stack inference tests are not run in CI here because they require the external tree and large checkpoints.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-151ecddc-df65-4223-9d42-ff2d4a9e617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-151ecddc-df65-4223-9d42-ff2d4a9e617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

