### PR TITLE
Integrate CycleDiff as a community checkout bridge

### DIFF
--- a/examples/community/README.md
+++ b/examples/community/README.md
@@ -40,6 +40,7 @@ from examples.community.parallel_gan import ParaGAN, Resrecon, ParallelGANTraine
 | [`lddbm/`](../lddbm/) | [Bosch Research, NeurIPS 2025](https://github.com/boschresearch/Multimodal-Distribution-Translation-MDT) | LDDBM: Latent diffusion bridge for super-resolution (16→128); training in `examples/lddbm/` |
 | [`ddib/`](ddib/) | [Su et al., ICLR 2023](https://github.com/suxuann/ddib) | DDIB for OpenAI/guided_diffusion-style checkpoints; dual source/target UNets |
 | [`cdtsde/`](cdtsde/) | CDTSDE/PSCDE | ControlLDM for solar defect identification; convert raw .ckpt and one-stop inference |
+| [`cyclediff/`](cyclediff/) | [Zou et al., IEEE TIP 2026](https://arxiv.org/abs/2508.06625) | CycleDiff cycle latent diffusion for unpaired translation; requires local [CycleDiff](https://github.com/ZouShilong1024/CycleDiff) checkout |
 | [`diffuseit/`](diffuseit/) | [Kwon & Ye, ICLR 2023](https://arxiv.org/abs/2209.15264) | Diffusion-based image translation with disentangled style/content (text- and image-guided) |
 | [`diffusionrouter/`](diffusionrouter/) | Universal Multi-Domain Translation via Diffusion Routers | Conditional diffusion translation with explicit multi-hop routing across domains |
 | [`alignflow/`](alignflow/) | [Grover et al., AAAI 2020](https://arxiv.org/abs/1905.12892) | CycleFlow & Flow2Flow: unpaired translation via normalizing flows with cycle-consistent learning from multiple domains |
@@ -117,6 +118,31 @@ out = pipe(source_image=image, num_inference_steps=250, output_type="pil")
 ```
 
 **Converting from raw .pt:** See [ddib/README.md](ddib/README.md). Raw ImageNet256 and Synthetic log2D checkpoints may require architecture-specific config adjustments.
+
+---
+
+### CycleDiff (Community)
+
+**Paper:** *CycleDiff: Cycle Diffusion Models for Unpaired Image-to-image Translation* (Zou et al., IEEE TIP 2026)
+
+**Source:** [ZouShilong1024/CycleDiff](https://github.com/ZouShilong1024/CycleDiff) — clone locally; training and inference use the upstream YAML configs and scripts under that repository.
+
+**Quick start:**
+
+```python
+from examples.community.cyclediff import resolve_cyclediff_root, inject_cyclediff_sys_path
+
+root = resolve_cyclediff_root("/path/to/CycleDiff")
+inject_cyclediff_sys_path(root)
+```
+
+```bash
+python -m examples.community.cyclediff.train \
+  --cyclediff-root /path/to/CycleDiff \
+  train_uncond_ldm_cycle.py --cfg ./configs/your_dataset/translation_C_disc_timestep_ode_2.yaml
+```
+
+See [cyclediff/README.md](cyclediff/README.md) for submodule setup, environment variable `CYCLEDIFF_ROOT`, and citation.
 
 ---
 

--- a/examples/community/cyclediff/README.md
+++ b/examples/community/cyclediff/README.md
@@ -1,0 +1,55 @@
+# CycleDiff (community)
+
+**Paper:** *CycleDiff: Cycle Diffusion Models for Unpaired Image-to-image Translation* (Zou et al., IEEE TIP 2026) — [arXiv:2508.06625](https://arxiv.org/abs/2508.06625), [project page](https://zoushilong1024.github.io/CycleDiff/)
+
+**Source:** [ZouShilong1024/CycleDiff](https://github.com/ZouShilong1024/CycleDiff) (clone locally; this monorepo does not vendor the full upstream tree.)
+
+**Architecture:** Two latent diffusion models (domains A and B), cycle-consistent generators, and adversarial discriminators trained with the upstream `ddm/` stack, VAE, and YAML configs.
+
+## Install upstream code
+
+```bash
+git clone https://github.com/ZouShilong1024/CycleDiff.git
+cd CycleDiff
+pip install -r requirement.txt
+```
+
+Optional: add as a submodule at the monorepo root:
+
+```bash
+git submodule add https://github.com/ZouShilong1024/CycleDiff.git CycleDiff
+```
+
+## Use from this repository
+
+**Resolve the checkout** (environment variable `CYCLEDIFF_ROOT`, or paths `./CycleDiff`, `./projects/CycleDiff`, `./external/CycleDiff` relative to the monorepo root):
+
+```python
+from examples.community.cyclediff import resolve_cyclediff_root, inject_cyclediff_sys_path
+
+root = resolve_cyclediff_root("/path/to/CycleDiff")
+inject_cyclediff_sys_path(root)  # optional; enables `import ddm` in custom scripts
+```
+
+**Run upstream training** with working directory set to the CycleDiff root:
+
+```bash
+python -m examples.community.cyclediff.train \
+  --cyclediff-root /path/to/CycleDiff \
+  train_uncond_ldm_cycle.py --cfg ./configs/your_dataset/translation_C_disc_timestep_ode_2.yaml
+```
+
+Follow the upstream README for dataset layout, VAE and LDM pretraining, and `accelerate launch translation_uncond_ldm_cycle.py` for testing.
+
+## Citation
+
+```bibtex
+@article{zou2025cyclediff,
+  title={CycleDiff: Cycle Diffusion Models for Unpaired Image-to-image Translation},
+  author={Zou, Shilong and Huang, Yuhang and Yi, Renjiao and Zhu, Chenyang and Xu, Kai},
+  journal={arXiv preprint arXiv:2508.06625},
+  year={2025}
+}
+```
+
+Upstream code is MIT-licensed; see the CycleDiff repository `LICENSE`.

--- a/examples/community/cyclediff/__init__.py
+++ b/examples/community/cyclediff/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiff (Zou et al., TIP 2026) — https://github.com/ZouShilong1024/CycleDiff
+
+"""CycleDiff: cycle diffusion models for unpaired image-to-image translation.
+
+Upstream implementation: https://github.com/ZouShilong1024/CycleDiff
+
+This package provides path resolution and a thin CLI to run upstream training
+and evaluation scripts from a local clone. Install CycleDiff dependencies in
+your environment (see their ``requirement.txt``) before running training.
+"""
+
+from examples.community.cyclediff.model import CYCLEDIFF_REPO_URL
+from examples.community.cyclediff.pipeline import inject_cyclediff_sys_path, resolve_cyclediff_root
+
+__all__ = [
+    "CYCLEDIFF_REPO_URL",
+    "inject_cyclediff_sys_path",
+    "resolve_cyclediff_root",
+]

--- a/examples/community/cyclediff/model.py
+++ b/examples/community/cyclediff/model.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiff (Zou et al., TIP 2026) — https://github.com/ZouShilong1024/CycleDiff
+
+"""Upstream CycleDiff code lives in a separate checkout; see README.md.
+
+This module only holds stable identifiers for documentation and imports.
+"""
+
+CYCLEDIFF_REPO_URL = "https://github.com/ZouShilong1024/CycleDiff"
+
+__all__ = ["CYCLEDIFF_REPO_URL"]

--- a/examples/community/cyclediff/pipeline.py
+++ b/examples/community/cyclediff/pipeline.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiff (Zou et al., TIP 2026) — https://github.com/ZouShilong1024/CycleDiff
+
+"""Path resolution for a local CycleDiff repository checkout."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from examples.community.cyclediff.model import CYCLEDIFF_REPO_URL
+
+
+def _is_cyclediff_root(p: Path) -> bool:
+    if not p.is_dir():
+        return False
+    markers = (
+        p / "train_uncond_ldm_cycle.py",
+        p / "translation_uncond_ldm_cycle.py",
+        p / "ddm" / "__init__.py",
+    )
+    return all(m.is_file() for m in markers)
+
+
+def resolve_cyclediff_root(cyclediff_src_path: Optional[str | Path] = None) -> Path:
+    """Return the root directory of a CycleDiff clone.
+
+    Parameters
+    ----------
+    cyclediff_src_path : str | Path, optional
+        Explicit path to the CycleDiff repository root. When omitted, the
+        ``CYCLEDIFF_ROOT`` environment variable is checked, then common locations
+        next to this monorepo or the current working directory.
+
+    Returns
+    -------
+    Path
+        Resolved absolute path to the CycleDiff checkout.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no valid CycleDiff root can be found.
+    """
+    if cyclediff_src_path is not None:
+        p = Path(cyclediff_src_path).expanduser()
+        if _is_cyclediff_root(p):
+            return p.resolve()
+        raise FileNotFoundError(
+            f"CycleDiff source not found or incomplete at {p}. "
+            "Expected train_uncond_ldm_cycle.py, translation_uncond_ldm_cycle.py, and ddm/__init__.py."
+        )
+
+    env = os.environ.get("CYCLEDIFF_ROOT")
+    if env:
+        p = Path(env).expanduser()
+        if _is_cyclediff_root(p):
+            return p.resolve()
+        raise FileNotFoundError(
+            f"CYCLEDIFF_ROOT is set to {env!r} but that path is not a valid CycleDiff checkout."
+        )
+
+    root = Path(__file__).resolve().parents[4]
+    candidates = [
+        root / "CycleDiff",
+        root / "projects" / "CycleDiff",
+        root / "external" / "CycleDiff",
+        Path.cwd() / "CycleDiff",
+        Path.cwd() / "projects" / "CycleDiff",
+    ]
+    for p in candidates:
+        if _is_cyclediff_root(p):
+            return p.resolve()
+
+    raise FileNotFoundError(
+        f"CycleDiff source not found. Clone {CYCLEDIFF_REPO_URL} and set CYCLEDIFF_ROOT or pass "
+        "cyclediff_src_path, or place the repo at ./CycleDiff, ./projects/CycleDiff, or ./external/CycleDiff."
+    )
+
+
+def inject_cyclediff_sys_path(cyclediff_src_path: Optional[str | Path] = None) -> Path:
+    """Prepend the CycleDiff root to ``sys.path`` so ``import ddm`` works from upstream code.
+
+    Returns
+    -------
+    Path
+        The resolved CycleDiff root.
+    """
+    resolved = resolve_cyclediff_root(cyclediff_src_path)
+    s = str(resolved)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+    return resolved
+
+
+__all__ = ["inject_cyclediff_sys_path", "resolve_cyclediff_root"]

--- a/examples/community/cyclediff/train.py
+++ b/examples/community/cyclediff/train.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiff (Zou et al., TIP 2026) — https://github.com/ZouShilong1024/CycleDiff
+
+"""Run CycleDiff upstream training or translation scripts from a local checkout.
+
+Example
+-------
+.. code-block:: bash
+
+    python -m examples.community.cyclediff.train \\
+        --cyclediff-root /path/to/CycleDiff \\
+        train_uncond_ldm_cycle.py --cfg ./configs/dataset/translation_C_disc_timestep_ode_2.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from examples.community.cyclediff.pipeline import resolve_cyclediff_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Execute a CycleDiff script (train_vae.py, train_uncond_ldm_cycle.py, etc.) "
+        "with working directory set to the CycleDiff root."
+    )
+    parser.add_argument(
+        "--cyclediff-root",
+        type=Path,
+        default=None,
+        help="Path to CycleDiff clone (overrides CYCLEDIFF_ROOT and auto-discovery).",
+    )
+    parser.add_argument(
+        "script_and_args",
+        nargs=argparse.REMAINDER,
+        help="Script name and arguments, e.g. train_uncond_ldm_cycle.py --cfg ./configs/....yaml",
+    )
+    args = parser.parse_args(argv)
+
+    rest = args.script_and_args
+    if rest and rest[0] == "--":
+        rest = rest[1:]
+    if not rest:
+        parser.error(
+            "Pass the upstream script and its arguments after optional --cyclediff-root, "
+            "e.g. train_uncond_ldm_cycle.py --cfg ./configs/foo/translation_C_disc_timestep_ode_2.yaml"
+        )
+
+    script_name = rest[0]
+    script_args = rest[1:]
+    root = resolve_cyclediff_root(args.cyclediff_root)
+    script_path = root / script_name
+    if not script_path.is_file():
+        raise FileNotFoundError(f"Script not found under CycleDiff root: {script_path}")
+
+    cmd = [sys.executable, str(script_path), *script_args]
+    return subprocess.call(cmd, cwd=str(root))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_community_pipelines.py
+++ b/tests/test_community_pipelines.py
@@ -3,6 +3,8 @@
 
 """Tests for community pipelines."""
 
+import sys
+
 import pytest
 import torch
 
@@ -939,3 +941,51 @@ class TestEGSDEPipeline:
 
         with pytest.raises(ValueError, match="Unknown EGSDE task"):
             load_egsde_community_pipeline(fake, task="unknown_task", device="cpu")
+
+
+# ---------------------------------------------------------------------------
+# CycleDiff (Zou et al., IEEE TIP 2026)
+# ---------------------------------------------------------------------------
+
+
+class TestCycleDiffIntegration:
+    """Tests for the CycleDiff community bridge (local checkout)."""
+
+    def test_cyclediff_imports(self):
+        from examples.community.cyclediff import (
+            CYCLEDIFF_REPO_URL,
+            inject_cyclediff_sys_path,
+            resolve_cyclediff_root,
+        )
+
+        assert CYCLEDIFF_REPO_URL.endswith("CycleDiff")
+        assert callable(resolve_cyclediff_root)
+        assert callable(inject_cyclediff_sys_path)
+
+    def test_resolve_cyclediff_explicit_missing_raises(self):
+        from examples.community.cyclediff import resolve_cyclediff_root
+
+        with pytest.raises(FileNotFoundError):
+            resolve_cyclediff_root("/tmp/nonexistent-cyclediff-checkout-xyz")
+
+    def test_resolve_and_inject_with_minimal_fake_tree(self, tmp_path):
+        from examples.community.cyclediff import inject_cyclediff_sys_path, resolve_cyclediff_root
+
+        (tmp_path / "train_uncond_ldm_cycle.py").write_text("# marker\n")
+        (tmp_path / "translation_uncond_ldm_cycle.py").write_text("# marker\n")
+        (tmp_path / "ddm").mkdir()
+        (tmp_path / "ddm" / "__init__.py").write_text("")
+        root = resolve_cyclediff_root(tmp_path)
+        assert root == tmp_path.resolve()
+        inject_cyclediff_sys_path(tmp_path)
+        assert str(tmp_path.resolve()) in sys.path
+
+    def test_train_main_runs_upstream_script_stub(self, tmp_path):
+        from examples.community.cyclediff.train import main
+
+        (tmp_path / "translation_uncond_ldm_cycle.py").write_text("# marker\n")
+        (tmp_path / "ddm").mkdir()
+        (tmp_path / "ddm" / "__init__.py").write_text("")
+        (tmp_path / "train_uncond_ldm_cycle.py").write_text("import sys\nsys.exit(0)\n")
+        rc = main(["--cyclediff-root", str(tmp_path), "train_uncond_ldm_cycle.py"])
+        assert rc == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds a **community integration** for [CycleDiff](https://github.com/ZouShilong1024/CycleDiff) (Zou et al., IEEE TIP 2026). The upstream repository is a full standalone codebase (LDM, VAE, `ddm/`, configs), so it is **not vendored** here. Instead, `examples/community/cyclediff/` provides:

- `resolve_cyclediff_root()` — locate a local clone via an explicit path, `CYCLEDIFF_ROOT`, or common paths (`./CycleDiff`, `./projects/CycleDiff`, `./external/CycleDiff`).
- `inject_cyclediff_sys_path()` — prepend the clone to `sys.path` for custom scripts that `import ddm`.
- `python -m examples.community.cyclediff.train` — run upstream scripts with `cwd` set to the CycleDiff root (so relative configs and imports behave like upstream).

Documentation lives in `examples/community/cyclediff/README.md`; the community index table and a short “CycleDiff (Community)” section were added to `examples/community/README.md`.

## Tests

- `tests/test_community_pipelines.py`: `TestCycleDiffIntegration` (imports, invalid path, fake tree resolution/injection, stub script execution via `train.main`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d7f0cc2-ed71-43a8-851b-db633deb45dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d7f0cc2-ed71-43a8-851b-db633deb45dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

