### PR TITLE
Integrate humansensinglab/cycle-diffusion (ICCV 2023) community bridge

### DIFF
--- a/examples/community/README.md
+++ b/examples/community/README.md
@@ -41,6 +41,7 @@ from examples.community.parallel_gan import ParaGAN, Resrecon, ParallelGANTraine
 | [`ddib/`](ddib/) | [Su et al., ICLR 2023](https://github.com/suxuann/ddib) | DDIB for OpenAI/guided_diffusion-style checkpoints; dual source/target UNets |
 | [`cdtsde/`](cdtsde/) | CDTSDE/PSCDE | ControlLDM for solar defect identification; convert raw .ckpt and one-stop inference |
 | [`cyclediff/`](cyclediff/) | [Zou et al., IEEE TIP 2026](https://arxiv.org/abs/2508.06625) | CycleDiff cycle latent diffusion for unpaired translation; requires local [CycleDiff](https://github.com/ZouShilong1024/CycleDiff) checkout |
+| [`cycle_diffusion/`](cycle_diffusion/) | [Wu & De la Torre, ICCV 2023](https://arxiv.org/abs/2210.05559) | CycleDiffusion zero-shot editing with stochastic diffusion models; requires local [humansensinglab/cycle-diffusion](https://github.com/humansensinglab/cycle-diffusion) checkout |
 | [`diffuseit/`](diffuseit/) | [Kwon & Ye, ICLR 2023](https://arxiv.org/abs/2209.15264) | Diffusion-based image translation with disentangled style/content (text- and image-guided) |
 | [`diffusionrouter/`](diffusionrouter/) | Universal Multi-Domain Translation via Diffusion Routers | Conditional diffusion translation with explicit multi-hop routing across domains |
 | [`alignflow/`](alignflow/) | [Grover et al., AAAI 2020](https://arxiv.org/abs/1905.12892) | CycleFlow & Flow2Flow: unpaired translation via normalizing flows with cycle-consistent learning from multiple domains |
@@ -143,6 +144,32 @@ python -m examples.community.cyclediff.train \
 ```
 
 See [cyclediff/README.md](cyclediff/README.md) for submodule setup, environment variable `CYCLEDIFF_ROOT`, and citation.
+
+---
+
+### CycleDiffusion (community)
+
+**Paper:** *A Latent Space of Stochastic Diffusion Models for Zero-Shot Image Editing and Guidance* (Wu & De la Torre, ICCV 2023)
+
+**Source:** [humansensinglab/cycle-diffusion](https://github.com/humansensinglab/cycle-diffusion) — clone locally; evaluation uses configs under `config/experiments/` in that repository.
+
+**Quick start:**
+
+```python
+from examples.community.cycle_diffusion import resolve_cycle_diffusion_root, inject_cycle_diffusion_sys_path
+
+root = resolve_cycle_diffusion_root("/path/to/cycle-diffusion")
+inject_cycle_diffusion_sys_path(root)
+```
+
+```bash
+python -m examples.community.cycle_diffusion.train \
+  --cycle-diffusion-root /path/to/cycle-diffusion \
+  main.py --cfg config/experiments/translate_text2img256_stable_diffusion_stochastic_1.cfg \
+  --run_name demo --do_eval --output_dir output/demo
+```
+
+See [cycle_diffusion/README.md](cycle_diffusion/README.md) for environment setup, `CYCLE_DIFFUSION_ROOT`, and how this differs from the unrelated [CycleDiff](cyclediff/) integration.
 
 ---
 

--- a/examples/community/cycle_diffusion/README.md
+++ b/examples/community/cycle_diffusion/README.md
@@ -1,0 +1,64 @@
+# CycleDiffusion (community)
+
+**Paper:** *A Latent Space of Stochastic Diffusion Models for Zero-Shot Image Editing and Guidance* (Wu & De la Torre, ICCV 2023) — [arXiv:2210.05559](https://arxiv.org/abs/2210.05559), [project page](https://chenwu.io/project/cycle-diffusion/)
+
+**Source:** [humansensinglab/cycle-diffusion](https://github.com/humansensinglab/cycle-diffusion) (maintained fork; original development by [ChenWu98/cycle-diffusion](https://github.com/ChenWu98/cycle-diffusion)). Clone locally; this monorepo does not vendor the full upstream tree.
+
+**Note:** This is **not** the same method as [CycleDiff](../cyclediff/) (Zou et al., IEEE TIP 2026), which targets cycle latent diffusion for unpaired translation.
+
+**Architecture:** Hugging Face `Trainer`-style loop in `main.py`, task configs under `config/`, models under `model/`, and CLIP-based evaluation.
+
+## Install upstream code
+
+```bash
+git clone https://github.com/humansensinglab/cycle-diffusion.git
+cd cycle-diffusion
+conda env create -f environment.yml
+conda activate generative_prompt
+```
+
+Follow the upstream README for CLIP, PyTorch, taming-transformers, checkpoints under `ckpts/`, and wandb setup.
+
+Optional submodule at the monorepo root:
+
+```bash
+git submodule add https://github.com/humansensinglab/cycle-diffusion.git cycle-diffusion
+```
+
+## Use from this repository
+
+**Resolve the checkout** (environment variable `CYCLE_DIFFUSION_ROOT`, or paths `./cycle-diffusion`, `./projects/cycle-diffusion`, `./external/cycle-diffusion` relative to the monorepo root):
+
+```python
+from examples.community.cycle_diffusion import (
+    resolve_cycle_diffusion_root,
+    inject_cycle_diffusion_sys_path,
+)
+
+root = resolve_cycle_diffusion_root("/path/to/cycle-diffusion")
+inject_cycle_diffusion_sys_path(root)  # optional; enables `import model`, `import trainer`, etc.
+```
+
+**Run upstream** with working directory set to the clone root. Experiment configs in this fork live under `config/experiments/` (not a top-level `experiments/` folder):
+
+```bash
+python -m examples.community.cycle_diffusion.train \
+  --cycle-diffusion-root /path/to/cycle-diffusion \
+  main.py --cfg config/experiments/translate_text2img256_stable_diffusion_stochastic_1.cfg \
+  --run_name demo --do_eval --output_dir output/demo
+```
+
+For multi-GPU, use `torch.distributed.launch` or `accelerate` as in the upstream README, still invoking `main.py` from the clone root.
+
+## Citation
+
+```bibtex
+@inproceedings{cyclediffusion,
+  title={A Latent Space of Stochastic Diffusion Models for Zero-Shot Image Editing and Guidance},
+  author={Wu, Chen Henry and De la Torre, Fernando},
+  booktitle={ICCV},
+  year={2023},
+}
+```
+
+Upstream code uses the X11 License; see the repository `LICENSE`.

--- a/examples/community/cycle_diffusion/__init__.py
+++ b/examples/community/cycle_diffusion/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiffusion (Wu & De la Torre, ICCV 2023) — https://github.com/humansensinglab/cycle-diffusion
+
+"""CycleDiffusion: zero-shot image editing with stochastic diffusion models (ICCV 2023).
+
+Upstream implementation: https://github.com/humansensinglab/cycle-diffusion
+
+This package provides path resolution and a thin CLI to run upstream ``main.py`` (and other
+scripts) from a local clone. Install upstream dependencies (see their ``environment.yml``)
+before running training or evaluation.
+"""
+
+from examples.community.cycle_diffusion.model import CYCLE_DIFFUSION_REPO_URL
+from examples.community.cycle_diffusion.pipeline import inject_cycle_diffusion_sys_path, resolve_cycle_diffusion_root
+
+__all__ = [
+    "CYCLE_DIFFUSION_REPO_URL",
+    "inject_cycle_diffusion_sys_path",
+    "resolve_cycle_diffusion_root",
+]

--- a/examples/community/cycle_diffusion/model.py
+++ b/examples/community/cycle_diffusion/model.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiffusion (Wu & De la Torre, ICCV 2023) — https://github.com/humansensinglab/cycle-diffusion
+
+"""Upstream CycleDiffusion (ICCV 2023) lives in a separate checkout; see README.md.
+
+This module only holds stable identifiers for documentation and imports.
+"""
+
+CYCLE_DIFFUSION_REPO_URL = "https://github.com/humansensinglab/cycle-diffusion"
+
+__all__ = ["CYCLE_DIFFUSION_REPO_URL"]

--- a/examples/community/cycle_diffusion/pipeline.py
+++ b/examples/community/cycle_diffusion/pipeline.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiffusion (Wu & De la Torre, ICCV 2023) — https://github.com/humansensinglab/cycle-diffusion
+
+"""Path resolution for a local humansensinglab/cycle-diffusion repository checkout."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from examples.community.cycle_diffusion.model import CYCLE_DIFFUSION_REPO_URL
+
+
+def _is_cycle_diffusion_root(p: Path) -> bool:
+    if not p.is_dir():
+        return False
+    markers = (
+        p / "main.py",
+        p / "trainer" / "trainer.py",
+        p / "utils" / "config_utils.py",
+        p / "model" / "__init__.py",
+    )
+    return all(m.is_file() for m in markers)
+
+
+def resolve_cycle_diffusion_root(src_path: Optional[str | Path] = None) -> Path:
+    """Return the root directory of a cycle-diffusion clone.
+
+    Parameters
+    ----------
+    src_path : str | Path, optional
+        Explicit path to the repository root. When omitted, the
+        ``CYCLE_DIFFUSION_ROOT`` environment variable is checked, then common
+        locations next to this monorepo or the current working directory.
+
+    Returns
+    -------
+    Path
+        Resolved absolute path to the checkout.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no valid root can be found.
+    """
+    if src_path is not None:
+        p = Path(src_path).expanduser()
+        if _is_cycle_diffusion_root(p):
+            return p.resolve()
+        raise FileNotFoundError(
+            f"cycle-diffusion source not found or incomplete at {p}. "
+            "Expected main.py, trainer/trainer.py, utils/config_utils.py, and model/__init__.py."
+        )
+
+    env = os.environ.get("CYCLE_DIFFUSION_ROOT")
+    if env:
+        p = Path(env).expanduser()
+        if _is_cycle_diffusion_root(p):
+            return p.resolve()
+        raise FileNotFoundError(
+            f"CYCLE_DIFFUSION_ROOT is set to {env!r} but that path is not a valid cycle-diffusion checkout."
+        )
+
+    root = Path(__file__).resolve().parents[4]
+    candidates = [
+        root / "cycle-diffusion",
+        root / "projects" / "cycle-diffusion",
+        root / "external" / "cycle-diffusion",
+        Path.cwd() / "cycle-diffusion",
+        Path.cwd() / "projects" / "cycle-diffusion",
+    ]
+    for p in candidates:
+        if _is_cycle_diffusion_root(p):
+            return p.resolve()
+
+    raise FileNotFoundError(
+        f"cycle-diffusion source not found. Clone {CYCLE_DIFFUSION_REPO_URL} and set CYCLE_DIFFUSION_ROOT or pass "
+        "src_path, or place the repo at ./cycle-diffusion, ./projects/cycle-diffusion, or ./external/cycle-diffusion."
+    )
+
+
+def inject_cycle_diffusion_sys_path(src_path: Optional[str | Path] = None) -> Path:
+    """Prepend the cycle-diffusion root to ``sys.path`` for imports of ``model``, ``trainer``, etc.
+
+    Returns
+    -------
+    Path
+        The resolved repository root.
+    """
+    resolved = resolve_cycle_diffusion_root(src_path)
+    s = str(resolved)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+    return resolved
+
+
+__all__ = ["inject_cycle_diffusion_sys_path", "resolve_cycle_diffusion_root"]

--- a/examples/community/cycle_diffusion/train.py
+++ b/examples/community/cycle_diffusion/train.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: CycleDiffusion (Wu & De la Torre, ICCV 2023) — https://github.com/humansensinglab/cycle-diffusion
+
+"""Run upstream cycle-diffusion entry points from a local checkout.
+
+Example
+-------
+.. code-block:: bash
+
+    python -m examples.community.cycle_diffusion.train \\
+        --cycle-diffusion-root /path/to/cycle-diffusion \\
+        main.py --cfg config/experiments/translate_text2img256_stable_diffusion_stochastic_1.cfg \\
+        --run_name demo --do_eval --output_dir output/demo
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from examples.community.cycle_diffusion.pipeline import resolve_cycle_diffusion_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Execute a cycle-diffusion script (typically main.py) with working directory "
+        "set to the repository root."
+    )
+    parser.add_argument(
+        "--cycle-diffusion-root",
+        type=Path,
+        default=None,
+        help="Path to cycle-diffusion clone (overrides CYCLE_DIFFUSION_ROOT and auto-discovery).",
+    )
+    parser.add_argument(
+        "script_and_args",
+        nargs=argparse.REMAINDER,
+        help="Script name and arguments, e.g. main.py --cfg config/experiments/....cfg ...",
+    )
+    args = parser.parse_args(argv)
+
+    rest = args.script_and_args
+    if rest and rest[0] == "--":
+        rest = rest[1:]
+    if not rest:
+        parser.error(
+            "Pass the upstream script and its arguments after optional --cycle-diffusion-root, "
+            "e.g. main.py --cfg config/experiments/translate_text2img256_stable_diffusion_stochastic_1.cfg"
+        )
+
+    script_name = rest[0]
+    script_args = rest[1:]
+    root = resolve_cycle_diffusion_root(args.cycle_diffusion_root)
+    script_path = root / script_name
+    if not script_path.is_file():
+        raise FileNotFoundError(f"Script not found under cycle-diffusion root: {script_path}")
+
+    cmd = [sys.executable, str(script_path), *script_args]
+    return subprocess.call(cmd, cwd=str(root))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_community_pipelines.py
+++ b/tests/test_community_pipelines.py
@@ -989,3 +989,57 @@ class TestCycleDiffIntegration:
         (tmp_path / "train_uncond_ldm_cycle.py").write_text("import sys\nsys.exit(0)\n")
         rc = main(["--cyclediff-root", str(tmp_path), "train_uncond_ldm_cycle.py"])
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# CycleDiffusion (Wu & De la Torre, ICCV 2023)
+# ---------------------------------------------------------------------------
+
+
+class TestCycleDiffusionIntegration:
+    """Tests for the humansensinglab/cycle-diffusion community bridge (local checkout)."""
+
+    def test_cycle_diffusion_imports(self):
+        from examples.community.cycle_diffusion import (
+            CYCLE_DIFFUSION_REPO_URL,
+            inject_cycle_diffusion_sys_path,
+            resolve_cycle_diffusion_root,
+        )
+
+        assert "humansensinglab/cycle-diffusion" in CYCLE_DIFFUSION_REPO_URL
+        assert callable(resolve_cycle_diffusion_root)
+        assert callable(inject_cycle_diffusion_sys_path)
+
+    def test_resolve_cycle_diffusion_explicit_missing_raises(self):
+        from examples.community.cycle_diffusion import resolve_cycle_diffusion_root
+
+        with pytest.raises(FileNotFoundError):
+            resolve_cycle_diffusion_root("/tmp/nonexistent-cycle-diffusion-checkout-xyz")
+
+    def test_resolve_and_inject_with_minimal_fake_tree(self, tmp_path):
+        from examples.community.cycle_diffusion import inject_cycle_diffusion_sys_path, resolve_cycle_diffusion_root
+
+        (tmp_path / "main.py").write_text("# marker\n")
+        (tmp_path / "trainer").mkdir()
+        (tmp_path / "trainer" / "trainer.py").write_text("# marker\n")
+        (tmp_path / "utils").mkdir()
+        (tmp_path / "utils" / "config_utils.py").write_text("# marker\n")
+        (tmp_path / "model").mkdir()
+        (tmp_path / "model" / "__init__.py").write_text("")
+        root = resolve_cycle_diffusion_root(tmp_path)
+        assert root == tmp_path.resolve()
+        inject_cycle_diffusion_sys_path(tmp_path)
+        assert str(tmp_path.resolve()) in sys.path
+
+    def test_train_main_runs_upstream_script_stub(self, tmp_path):
+        from examples.community.cycle_diffusion.train import main
+
+        (tmp_path / "main.py").write_text("import sys\nsys.exit(0)\n")
+        (tmp_path / "trainer").mkdir()
+        (tmp_path / "trainer" / "trainer.py").write_text("# marker\n")
+        (tmp_path / "utils").mkdir()
+        (tmp_path / "utils" / "config_utils.py").write_text("# marker\n")
+        (tmp_path / "model").mkdir()
+        (tmp_path / "model" / "__init__.py").write_text("")
+        rc = main(["--cycle-diffusion-root", str(tmp_path), "main.py"])
+        assert rc == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `examples/community/cycle_diffusion/`, a thin integration for [humansensinglab/cycle-diffusion](https://github.com/humansensinglab/cycle-diffusion) (CycleDiffusion, ICCV 2023: zero-shot image editing with stochastic diffusion models). This mirrors the existing pattern used for other external repos (path resolution, optional `sys.path` injection, CLI to run upstream scripts with the correct working directory).

## Details

- **Discovery:** `CYCLE_DIFFUSION_ROOT` or `./cycle-diffusion`, `./projects/cycle-diffusion`, `./external/cycle-diffusion`.
- **CLI:** `python -m examples.community.cycle_diffusion.train --cycle-diffusion-root … main.py …`
- **Docs:** Notes that experiment configs in the current upstream tree live under `config/experiments/` (not top-level `experiments/` as in older README snippets), and clarifies this is **not** the same method as `examples/community/cyclediff/` (Zou et al., TIP 2026).
- **Tests:** `TestCycleDiffusionIntegration` in `tests/test_community_pipelines.py`.

## Testing

- `python3 -m pytest tests/test_community_pipelines.py::TestCycleDiffusionIntegration -q` (4 passed)
- `python3 -m ruff check examples/community/cycle_diffusion tests/test_community_pipelines.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31890e72-4fa2-4746-8ef5-d22f46ce1bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31890e72-4fa2-4746-8ef5-d22f46ce1bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

