### PR TITLE
Integrate SDEdit (ermongroup/SDEdit) community bridge

### DIFF
--- a/docs/credits.md
+++ b/docs/credits.md
@@ -28,3 +28,4 @@
 | [LDDBM](https://neurips.cc/virtual/2025/poster/116815) — Towards General Modality Translation with Contrastive and Predictive Latent Diffusion Bridge (Berman et al.) | NeurIPS 2025 | [boschresearch/Multimodal-Distribution-Translation-MDT](https://github.com/boschresearch/Multimodal-Distribution-Translation-MDT) |
 | [FCDM](https://arxiv.org/abs/2603.09408) — Reviving ConvNeXt for Efficient Convolutional Diffusion Models | CVPR 2026 | [star-kwon/FCDM](https://github.com/star-kwon/FCDM) |
 | [SAR2Optical](https://github.com/yuuIind/SAR2Optical) — SAR-to-Optical Image Translation | — | [yuuIind/SAR2Optical](https://github.com/yuuIind/SAR2Optical) |
+| [SDEdit](https://arxiv.org/abs/2108.01073) — Guided Image Synthesis and Editing with Stochastic Differential Equations | ICLR 2022 | [ermongroup/SDEdit](https://github.com/ermongroup/SDEdit) |

--- a/examples/community/README.md
+++ b/examples/community/README.md
@@ -42,6 +42,7 @@ from examples.community.parallel_gan import ParaGAN, Resrecon, ParallelGANTraine
 | [`cdtsde/`](cdtsde/) | CDTSDE/PSCDE | ControlLDM for solar defect identification; convert raw .ckpt and one-stop inference |
 | [`cyclediff/`](cyclediff/) | [Zou et al., IEEE TIP 2026](https://arxiv.org/abs/2508.06625) | CycleDiff cycle latent diffusion for unpaired translation; requires local [CycleDiff](https://github.com/ZouShilong1024/CycleDiff) checkout |
 | [`cycle_diffusion/`](cycle_diffusion/) | [Wu & De la Torre, ICCV 2023](https://arxiv.org/abs/2210.05559) | CycleDiffusion zero-shot editing with stochastic diffusion models; requires local [humansensinglab/cycle-diffusion](https://github.com/humansensinglab/cycle-diffusion) checkout |
+| [`sdedit/`](sdedit/) | [Meng et al., ICLR 2022](https://arxiv.org/abs/2108.01073) | SDEdit guided synthesis and editing with VP-SDEs; requires local [ermongroup/SDEdit](https://github.com/ermongroup/SDEdit) checkout |
 | [`diffuseit/`](diffuseit/) | [Kwon & Ye, ICLR 2023](https://arxiv.org/abs/2209.15264) | Diffusion-based image translation with disentangled style/content (text- and image-guided) |
 | [`diffusionrouter/`](diffusionrouter/) | Universal Multi-Domain Translation via Diffusion Routers | Conditional diffusion translation with explicit multi-hop routing across domains |
 | [`alignflow/`](alignflow/) | [Grover et al., AAAI 2020](https://arxiv.org/abs/1905.12892) | CycleFlow & Flow2Flow: unpaired translation via normalizing flows with cycle-consistent learning from multiple domains |
@@ -170,6 +171,32 @@ python -m examples.community.cycle_diffusion.train \
 ```
 
 See [cycle_diffusion/README.md](cycle_diffusion/README.md) for environment setup, `CYCLE_DIFFUSION_ROOT`, and how this differs from the unrelated [CycleDiff](cyclediff/) integration.
+
+---
+
+### SDEdit (community)
+
+**Paper:** *SDEdit: Guided Image Synthesis and Editing with Stochastic Differential Equations* (Meng et al., ICLR 2022)
+
+**Source:** [ermongroup/SDEdit](https://github.com/ermongroup/SDEdit) — clone locally; stroke-based generation and editing use `main.py` with YAML configs under `configs/`.
+
+**Quick start:**
+
+```python
+from examples.community.sdedit import resolve_sdedit_root, inject_sdedit_sys_path
+
+root = resolve_sdedit_root("/path/to/SDEdit")
+inject_sdedit_sys_path(root)
+```
+
+```bash
+python -m examples.community.sdedit.train \
+  --sdedit-root /path/to/SDEdit \
+  main.py --exp ./runs/ --config bedroom.yml --sample -i images \
+  --npy_name lsun_bedroom1 --sample_step 3 --t 500 --ni
+```
+
+See [sdedit/README.md](sdedit/README.md) for environment setup, `SDEDIT_ROOT`, and citation.
 
 ---
 

--- a/examples/community/__init__.py
+++ b/examples/community/__init__.py
@@ -31,4 +31,5 @@ Available community pipelines:
 * ``diffusionrouter/`` – DiffusionRouter (kvmduc) universal multi-domain routing with conditional diffusion
 * ``syndiff/`` – SynDiff (Özbey et al., IEEE TMI 2023) – unsupervised medical image translation with adversarial diffusion
 * ``selfrdb/`` – SelfRDB (Arslan et al., Medical Image Analysis 2024) – self-consistent recursive diffusion bridge for medical synthesis
+* ``sdedit/`` – SDEdit (Meng et al., ICLR 2022) – guided image synthesis and editing with SDEs; requires local [ermongroup/SDEdit](https://github.com/ermongroup/SDEdit) checkout
 """

--- a/examples/community/sdedit/README.md
+++ b/examples/community/sdedit/README.md
@@ -1,0 +1,70 @@
+# SDEdit (community)
+
+**Paper:** *SDEdit: Guided Image Synthesis and Editing with Stochastic Differential Equations* (Meng et al., ICLR 2022) — [arXiv:2108.01073](https://arxiv.org/abs/2108.01073), [project page](https://sde-image-editing.github.io/)
+
+**Source:** [ermongroup/SDEdit](https://github.com/ermongroup/SDEdit). Clone locally; this monorepo does not vendor the full upstream tree.
+
+**Architecture:** VP-SDE image editing and stroke-based generation with configs under `configs/` and sampling in `runners/image_editing.py`. Pretrained checkpoints are downloaded automatically when you run sampling (see upstream README).
+
+## Install upstream code
+
+```bash
+git clone https://github.com/ermongroup/SDEdit.git
+cd SDEdit
+pip install -r requirements.txt
+```
+
+Follow the upstream README for data format (`[image, mask]` tensors), example `.npy` inputs, and Colab.
+
+Optional placement next to this repository (auto-discovered):
+
+```bash
+git clone https://github.com/ermongroup/SDEdit.git
+# or: git submodule add https://github.com/ermongroup/SDEdit.git SDEdit
+```
+
+## Use from this repository
+
+**Resolve the checkout** (environment variable `SDEDIT_ROOT`, or paths `./SDEdit`, `./sdedit`, `./projects/SDEdit`, `./external/SDEdit` relative to the monorepo root):
+
+```python
+from examples.community.sdedit import (
+    resolve_sdedit_root,
+    inject_sdedit_sys_path,
+)
+
+root = resolve_sdedit_root("/path/to/SDEdit")
+inject_sdedit_sys_path(root)  # optional; enables `import runners`, `import models`, etc.
+```
+
+**Run upstream** with working directory set to the clone root:
+
+```bash
+python -m examples.community.sdedit.train \
+  --sdedit-root /path/to/SDEdit \
+  main.py --exp ./runs/ --config bedroom.yml --sample -i images \
+  --npy_name lsun_bedroom1 --sample_step 3 --t 500 --ni
+```
+
+Stroke-based editing (church example from upstream):
+
+```bash
+python -m examples.community.sdedit.train \
+  --sdedit-root /path/to/SDEdit \
+  main.py --exp ./runs/ --config church.yml --sample -i images \
+  --npy_name lsun_edit --sample_step 3 --t 500 --ni
+```
+
+## Citation
+
+```bibtex
+@inproceedings{
+      meng2022sdedit,
+      title={{SDE}dit: Guided Image Synthesis and Editing with Stochastic Differential Equations},
+      author={Chenlin Meng and Yutong He and Yang Song and Jiaming Song and Jiajun Wu and Jun-Yan Zhu and Stefano Ermon},
+      booktitle={International Conference on Learning Representations},
+      year={2022},
+}
+```
+
+Upstream code is licensed under the MIT License; see the repository `LICENSE`.

--- a/examples/community/sdedit/__init__.py
+++ b/examples/community/sdedit/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: SDEdit (Meng et al., ICLR 2022) — https://github.com/ermongroup/SDEdit
+
+"""SDEdit: guided image synthesis and editing with stochastic differential equations (ICLR 2022).
+
+Upstream implementation: https://github.com/ermongroup/SDEdit
+
+This package provides path resolution and a thin CLI to run upstream ``main.py`` from a local
+clone. Install upstream dependencies (see their ``requirements.txt``) before sampling.
+"""
+
+from examples.community.sdedit.model import SDEDIT_REPO_URL
+from examples.community.sdedit.pipeline import inject_sdedit_sys_path, resolve_sdedit_root
+
+__all__ = [
+    "SDEDIT_REPO_URL",
+    "inject_sdedit_sys_path",
+    "resolve_sdedit_root",
+]

--- a/examples/community/sdedit/model.py
+++ b/examples/community/sdedit/model.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: SDEdit (Meng et al., ICLR 2022) — https://github.com/ermongroup/SDEdit
+
+"""Upstream SDEdit lives in a separate checkout; see README.md.
+
+This module only holds stable identifiers for documentation and imports.
+"""
+
+SDEDIT_REPO_URL = "https://github.com/ermongroup/SDEdit"
+
+__all__ = ["SDEDIT_REPO_URL"]

--- a/examples/community/sdedit/pipeline.py
+++ b/examples/community/sdedit/pipeline.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: SDEdit (Meng et al., ICLR 2022) — https://github.com/ermongroup/SDEdit
+
+"""Path resolution for a local ermongroup/SDEdit repository checkout."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from examples.community.sdedit.model import SDEDIT_REPO_URL
+
+
+def _is_sdedit_root(p: Path) -> bool:
+    if not p.is_dir():
+        return False
+    markers = (
+        p / "main.py",
+        p / "runners" / "image_editing.py",
+        p / "models" / "diffusion.py",
+        p / "configs",
+    )
+    if not all(m.exists() for m in markers):
+        return False
+    if not (p / "configs").is_dir():
+        return False
+    return any((p / "configs").glob("*.yml"))
+
+
+def resolve_sdedit_root(src_path: Optional[str | Path] = None) -> Path:
+    """Return the root directory of an SDEdit clone.
+
+    Parameters
+    ----------
+    src_path : str | Path, optional
+        Explicit path to the repository root. When omitted, the
+        ``SDEDIT_ROOT`` environment variable is checked, then common
+        locations next to this monorepo or the current working directory.
+
+    Returns
+    -------
+    Path
+        Resolved absolute path to the checkout.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no valid root can be found.
+    """
+    if src_path is not None:
+        p = Path(src_path).expanduser()
+        if _is_sdedit_root(p):
+            return p.resolve()
+        raise FileNotFoundError(
+            f"SDEdit source not found or incomplete at {p}. "
+            "Expected main.py, runners/image_editing.py, models/diffusion.py, and configs/*.yml."
+        )
+
+    env = os.environ.get("SDEDIT_ROOT")
+    if env:
+        p = Path(env).expanduser()
+        if _is_sdedit_root(p):
+            return p.resolve()
+        raise FileNotFoundError(
+            f"SDEDIT_ROOT is set to {env!r} but that path is not a valid SDEdit checkout."
+        )
+
+    root = Path(__file__).resolve().parents[4]
+    candidates = [
+        root / "SDEdit",
+        root / "sdedit",
+        root / "projects" / "SDEdit",
+        root / "external" / "SDEdit",
+        Path.cwd() / "SDEdit",
+        Path.cwd() / "sdedit",
+        Path.cwd() / "projects" / "SDEdit",
+    ]
+    for p in candidates:
+        if _is_sdedit_root(p):
+            return p.resolve()
+
+    raise FileNotFoundError(
+        f"SDEdit source not found. Clone {SDEDIT_REPO_URL} and set SDEDIT_ROOT or pass "
+        "src_path, or place the repo at ./SDEdit, ./sdedit, ./projects/SDEdit, or ./external/SDEdit."
+    )
+
+
+def inject_sdedit_sys_path(src_path: Optional[str | Path] = None) -> Path:
+    """Prepend the SDEdit root to ``sys.path`` for imports of ``runners``, ``models``, etc.
+
+    Returns
+    -------
+    Path
+        The resolved repository root.
+    """
+    resolved = resolve_sdedit_root(src_path)
+    s = str(resolved)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+    return resolved
+
+
+__all__ = ["inject_sdedit_sys_path", "resolve_sdedit_root"]

--- a/examples/community/sdedit/train.py
+++ b/examples/community/sdedit/train.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 EarthBridge Team.
+# Credits: SDEdit (Meng et al., ICLR 2022) — https://github.com/ermongroup/SDEdit
+
+"""Run upstream SDEdit entry points from a local checkout.
+
+Example
+-------
+.. code-block:: bash
+
+    python -m examples.community.sdedit.train \\
+        --sdedit-root /path/to/SDEdit \\
+        main.py --exp ./runs/ --config bedroom.yml --sample -i images \\
+        --npy_name lsun_bedroom1 --sample_step 3 --t 500 --ni
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from examples.community.sdedit.pipeline import resolve_sdedit_root
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Execute an SDEdit script (typically main.py) with working directory "
+        "set to the repository root."
+    )
+    parser.add_argument(
+        "--sdedit-root",
+        type=Path,
+        default=None,
+        help="Path to SDEdit clone (overrides SDEDIT_ROOT and auto-discovery).",
+    )
+    parser.add_argument(
+        "script_and_args",
+        nargs=argparse.REMAINDER,
+        help="Script name and arguments, e.g. main.py --exp ./runs/ --config bedroom.yml ...",
+    )
+    args = parser.parse_args(argv)
+
+    rest = args.script_and_args
+    if rest and rest[0] == "--":
+        rest = rest[1:]
+    if not rest:
+        parser.error(
+            "Pass the upstream script and its arguments after optional --sdedit-root, "
+            "e.g. main.py --exp ./runs/ --config bedroom.yml --sample -i images --npy_name demo --ni"
+        )
+
+    script_name = rest[0]
+    script_args = rest[1:]
+    root = resolve_sdedit_root(args.sdedit_root)
+    script_path = root / script_name
+    if not script_path.is_file():
+        raise FileNotFoundError(f"Script not found under SDEdit root: {script_path}")
+
+    cmd = [sys.executable, str(script_path), *script_args]
+    return subprocess.call(cmd, cwd=str(root))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_community_pipelines.py
+++ b/tests/test_community_pipelines.py
@@ -1043,3 +1043,57 @@ class TestCycleDiffusionIntegration:
         (tmp_path / "model" / "__init__.py").write_text("")
         rc = main(["--cycle-diffusion-root", str(tmp_path), "main.py"])
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# SDEdit (Meng et al., ICLR 2022)
+# ---------------------------------------------------------------------------
+
+
+class TestSDEditIntegration:
+    """Tests for the ermongroup/SDEdit community bridge (local checkout)."""
+
+    def test_sdedit_imports(self):
+        from examples.community.sdedit import (
+            SDEDIT_REPO_URL,
+            inject_sdedit_sys_path,
+            resolve_sdedit_root,
+        )
+
+        assert "ermongroup/SDEdit" in SDEDIT_REPO_URL
+        assert callable(resolve_sdedit_root)
+        assert callable(inject_sdedit_sys_path)
+
+    def test_resolve_sdedit_explicit_missing_raises(self):
+        from examples.community.sdedit import resolve_sdedit_root
+
+        with pytest.raises(FileNotFoundError):
+            resolve_sdedit_root("/tmp/nonexistent-sdedit-checkout-xyz")
+
+    def test_resolve_and_inject_with_minimal_fake_tree(self, tmp_path):
+        from examples.community.sdedit import inject_sdedit_sys_path, resolve_sdedit_root
+
+        (tmp_path / "main.py").write_text("# marker\n")
+        (tmp_path / "runners").mkdir()
+        (tmp_path / "runners" / "image_editing.py").write_text("# marker\n")
+        (tmp_path / "models").mkdir()
+        (tmp_path / "models" / "diffusion.py").write_text("# marker\n")
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "bedroom.yml").write_text("data:\n  dataset: dummy\n")
+        root = resolve_sdedit_root(tmp_path)
+        assert root == tmp_path.resolve()
+        inject_sdedit_sys_path(tmp_path)
+        assert str(tmp_path.resolve()) in sys.path
+
+    def test_train_main_runs_upstream_script_stub(self, tmp_path):
+        from examples.community.sdedit.train import main
+
+        (tmp_path / "main.py").write_text("import sys\nsys.exit(0)\n")
+        (tmp_path / "runners").mkdir()
+        (tmp_path / "runners" / "image_editing.py").write_text("# marker\n")
+        (tmp_path / "models").mkdir()
+        (tmp_path / "models" / "diffusion.py").write_text("# marker\n")
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "bedroom.yml").write_text("data:\n  dataset: dummy\n")
+        rc = main(["--sdedit-root", str(tmp_path), "main.py"])
+        assert rc == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds a **community bridge** for [ermongroup/SDEdit](https://github.com/ermongroup/SDEdit) (ICLR 2022), following the same pattern as [CycleDiffusion](examples/community/cycle_diffusion/): local clone discovery, optional `sys.path` injection, and a small CLI to run upstream `main.py` with the correct working directory.

## What was added

- `examples/community/sdedit/` — `resolve_sdedit_root`, `inject_sdedit_sys_path`, `SDEDIT_REPO_URL`, and `python -m examples.community.sdedit.train` delegating to the upstream repo.
- Auto-discovery paths: `./SDEdit`, `./sdedit`, `./projects/SDEdit`, `./external/SDEdit`, or `SDEDIT_ROOT`.
- Documentation in [examples/community/README.md](examples/community/README.md) and [examples/community/sdedit/README.md](examples/community/sdedit/README.md); citation row in [docs/credits.md](docs/credits.md).
- Unit tests in `tests/test_community_pipelines.py` (`TestSDEditIntegration`).

## Testing

- `python3 -m pytest tests/test_community_pipelines.py::TestSDEditIntegration -v`
- `ruff check examples/community/sdedit/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c5ff464-2d03-4a40-b43f-b7c2aa796cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c5ff464-2d03-4a40-b43f-b7c2aa796cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

